### PR TITLE
feat(3x-ui): MHSanaei 3x-ui v3.1.0 API-token compatibility (Phase 1)

### DIFF
--- a/Marzban.php
+++ b/Marzban.php
@@ -174,6 +174,7 @@ function getusers($location,$status)
     $header_value = 'Bearer ';
 
     $ch = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'panel');
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_HTTPGET, true);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -212,6 +213,7 @@ function getinbounds($location)
     $header_value = 'Bearer ';
 
     $ch = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'panel');
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_HTTPGET, true);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -403,6 +405,7 @@ function Get_System_Stats($location){
     $header_value = 'Bearer ';
 
     $ch = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'panel');
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_HTTPGET, true);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -491,6 +494,7 @@ function Modifyuser_node($location,$id_node,array $data)
     $url =  $marzban_list_get['url_panel'].'/api/node/'.$id_node;
     $payload = json_encode($data);
     $ch = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'panel');
 curl_setopt($ch, CURLOPT_URL, $url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
@@ -515,6 +519,7 @@ function hosts($location)
     $Check_token = token_panel($marzban_list_get['code_panel']);
     $url =  $marzban_list_get['url_panel'].'/api/hosts';
     $ch = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'panel');
 curl_setopt($ch, CURLOPT_URL, $url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');

--- a/alireza.php
+++ b/alireza.php
@@ -33,6 +33,7 @@ if (!function_exists('alireza_tls_verifyhost')) {
 
 function loginalireza($url,$username,$password){
 $curl = curl_init();
+if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
 curl_setopt_array($curl, array(
   CURLOPT_URL => $url.'/login',
   CURLOPT_RETURNTRANSFER => true,
@@ -60,6 +61,7 @@ function get_useralireza($username,$namepanel){
     if(isset($loginalirezapanel['errror']))return;
     $usernameac = $username;
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
 curl_setopt_array($curl, array(
   CURLOPT_URL => $marzban_list_get['url_panel'].'/xui/API/inbounds',
   CURLOPT_RETURNTRANSFER => true,
@@ -94,6 +96,7 @@ function checkportalireza($port,$namepanel){
     $loginalirezapanel = loginalireza($marzban_list_get['url_panel'],$marzban_list_get['username_panel'],$marzban_list_get['password_panel']);
     if(isset($loginalirezapanel['errror']))return;
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
 
 curl_setopt_array($curl, array(
   CURLOPT_URL => $marzban_list_get['url_panel'].'/xui/API/inbounds',
@@ -174,6 +177,7 @@ function addinboundalireza($namepanel, $usernameac, $Port, $Expire,$Total, $Uuid
     $configpanel = json_encode($config,true);
 
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
         CURLOPT_URL => $marzban_list_get['url_panel'].'/xui/API/inbounds/add',
         CURLOPT_RETURNTRANSFER => true,
@@ -207,6 +211,7 @@ function updateinboundalireza($namepanel, $inboundid,array $config){
     $configpanel = json_encode($config,true);
 
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
         CURLOPT_URL => $marzban_list_get['url_panel'].'/xui/API/inbounds/update/'.$inboundid,
         CURLOPT_RETURNTRANSFER => true,
@@ -239,6 +244,7 @@ function ResetUserDataUsagealireza($usernamepanel, $namepanel){
     $loginalirezapanel = loginalireza($marzban_list_get['url_panel'],$marzban_list_get['username_panel'],$marzban_list_get['password_panel']);
     if(isset($loginalirezapanel['errror']))return;
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
 curl_setopt_array($curl, array(
   CURLOPT_URL => $marzban_list_get['url_panel'].'/xui/API/inbounds/resetAllClientTraffics/'.$data_user['id'],
   CURLOPT_RETURNTRANSFER => true,
@@ -273,6 +279,7 @@ function remove_useralireza($location,$username){
     $loginalirezapanel = loginalireza($marzban_list_get['url_panel'],$marzban_list_get['username_panel'],$marzban_list_get['password_panel']);
     if(isset($loginalirezapanel['errror']))return;
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
   CURLOPT_URL => $marzban_list_get['url_panel'].'/xui/API/inbounds/del/'.$data_user['id'],
   CURLOPT_RETURNTRANSFER => true,
@@ -302,6 +309,7 @@ function get_onlineuseralireza($name_panel,$username){
     $loginalirezapanel = loginalireza($marzban_list_get['url_panel'],$marzban_list_get['username_panel'],$marzban_list_get['password_panel']);
     if(isset($loginalirezapanel['errror']))return;
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
 curl_setopt_array($curl, array(
   CURLOPT_URL => $marzban_list_get['url_panel'].'/xui/API/onlines',
   CURLOPT_RETURNTRANSFER => true,

--- a/alireza_single.php
+++ b/alireza_single.php
@@ -39,6 +39,7 @@ function get_clinetsalireza($username,$namepanel){
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $namepanel,"select");
     login($marzban_list_get['code_panel']);
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
 
 curl_setopt_array($curl, array(
   CURLOPT_URL => $marzban_list_get['url_panel'].'/xui/API/inbounds',
@@ -186,6 +187,7 @@ function get_onlineclialireza($name_panel,$username){
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $name_panel,"select");
     login($marzban_list_get['code_panel']);
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
 curl_setopt_array($curl, array(
   CURLOPT_URL => $marzban_list_get['url_panel'].'/xui/API/inbounds/onlines',
   CURLOPT_RETURNTRANSFER => true,

--- a/api/handlers/PaymentReceiptHandler.php
+++ b/api/handlers/PaymentReceiptHandler.php
@@ -189,6 +189,7 @@ final class PaymentReceiptHandler extends BaseHandler
     private function sendReceiptPhoto(string $apiKey, string $chatId, string $localPath, string $mime, string $caption, string $keyboardJson): ?string
     {
         $ch = curl_init('https://api.telegram.org/bot' . $apiKey . '/sendPhoto');
+        if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'telegram');
         $post = [
             'chat_id'      => $chatId,
             'caption'      => $caption,
@@ -239,6 +240,7 @@ final class PaymentReceiptHandler extends BaseHandler
             'reply_markup' => $keyboardJson,
         ];
         $ch = curl_init($url);
+        if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'telegram');
         curl_setopt_array($ch, [
             CURLOPT_POST           => true,
             CURLOPT_POSTFIELDS     => http_build_query($payload),
@@ -266,6 +268,7 @@ final class PaymentReceiptHandler extends BaseHandler
             'reply_markup' => $keyboardJson,
         ];
         $ch = curl_init($url);
+        if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'telegram');
         curl_setopt_array($ch, [
             CURLOPT_POST           => true,
             CURLOPT_POSTFIELDS     => http_build_query($payload),

--- a/api/handlers/ServiceActionHandler.php
+++ b/api/handlers/ServiceActionHandler.php
@@ -323,6 +323,7 @@ final class ServiceActionHandler extends BaseHandler
             'disable_web_page_preview' => true,
         ];
         $ch = curl_init($url);
+        if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'telegram');
         curl_setopt_array($ch, [
             CURLOPT_POST           => true,
             CURLOPT_POSTFIELDS     => http_build_query($payload),

--- a/botapi.php
+++ b/botapi.php
@@ -101,6 +101,9 @@ function telegram($method, $datas = [], $token = null)
         curl_setopt($ch, CURLOPT_TCP_KEEPALIVE, 1);
         curl_setopt($ch, CURLOPT_TCP_KEEPIDLE, 60);
         curl_setopt($ch, CURLOPT_TCP_KEEPINTVL, 30);
+        if (function_exists('faoxima_apply_curl_proxy')) {
+            faoxima_apply_curl_proxy($ch, 'telegram');
+        }
         if (!empty($preparedPayload['headers'])) {
             curl_setopt($ch, CURLOPT_HTTPHEADER, $preparedPayload['headers']);
         }

--- a/config.php
+++ b/config.php
@@ -81,3 +81,5 @@ $GLOBALS['usernamebot']                = $usernamebot;
 $GLOBALS['telegramCurlTimeout']        = $telegramCurlTimeout;
 $GLOBALS['telegramStrictIpValidation'] = $telegramStrictIpValidation;
 $GLOBALS['admin_panel_token']          = $admin_panel_token;
+
+require_once __DIR__ . '/proxy.php';

--- a/hiddify.php
+++ b/hiddify.php
@@ -8,6 +8,7 @@ function getdatauser($username,$location)
     $usernameac = $username;
     $url =  $marzban_list_get['url_panel'].'/api/v2/admin/user/';
     $ch = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($ch, 'panel');
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_HTTPGET, true);
     curl_setopt($ch,CURLOPT_TIMEOUT_MS, 4000);

--- a/ibsng/Modules/IBSng.php
+++ b/ibsng/Modules/IBSng.php
@@ -711,6 +711,7 @@ class IBSng
             throw new \Exception('Url specified in curl request is empty ');
         }
         $this->handler = curl_init();
+        if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($this->handler, 'panel');
         curl_setopt($this->handler, CURLOPT_CONNECTTIMEOUT, 0);
         curl_setopt($this->handler, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($this->handler, CURLOPT_URL, $url);

--- a/marzneshin.php
+++ b/marzneshin.php
@@ -41,6 +41,7 @@ function token_panelm($code_panel){
         )
     );
     $curl_token = curl_init($url_get_token);
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl_token, 'panel');
     curl_setopt_array($curl_token, $options);
     $token = curl_exec($curl_token);
     if (curl_error($curl_token)) {

--- a/mikrotik.php
+++ b/mikrotik.php
@@ -4,6 +4,7 @@ require_once 'function.php';
 
 function login_mikrotik($url,$username,$password){
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
       CURLOPT_URL => $url.'/rest/system/resource',
       CURLOPT_RETURNTRANSFER => true,
@@ -27,6 +28,7 @@ return $response;
 function addUser_mikrotik($name_panel,$username,$password,$group){
     $panel = select("marzban_panel","*","name_panel",$name_panel,"select");
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     $data = array(
         'name' => $username,
         'password' => $password
@@ -58,6 +60,7 @@ return $response;
 function set_profile_mikrotik($name_panel,$username,$prof_name){
     $panel = select("marzban_panel","*","name_panel",$name_panel,"select");
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     $data = array(
         'user' => $username,
         'profile' => $prof_name
@@ -88,6 +91,7 @@ return $response;
 function GetUsermikrotik($name_panel,$username){
     $panel = select("marzban_panel","*","name_panel",$name_panel,"select");
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
       CURLOPT_URL => $panel['url_panel'].'/rest/user-manager/user?name='.$username,
       CURLOPT_RETURNTRANSFER => true,
@@ -112,6 +116,7 @@ return $response;
 function GetUsermikrotik_volume($name_panel,$id){
     $panel = select("marzban_panel","*","name_panel",$name_panel,"select");
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     $data = array(
         'once' => true,
         '.id' => $id
@@ -153,6 +158,7 @@ function deleteUser_mikrotik($name_panel,$username){
         return json_encode(array("error" => "user-not-found", "username" => $username));
     }
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     $data = array(
         '.id' => $id
         );

--- a/panel/panels.php
+++ b/panel/panels.php
@@ -204,7 +204,7 @@ function faoxima_http_get(string $url, array $headers = []): array {
 }
 
 
-function faoxima_test_panel_auth(string $url, string $username, string $password, string $apiKey, string $type): array {
+function faoxima_test_panel_auth(string $url, string $username, string $password, string $apiKey, string $type, string $xuiToken = ''): array {
 
     
     if ($type === 'Manualsale') {
@@ -214,6 +214,26 @@ function faoxima_test_panel_auth(string $url, string $username, string $password
 
     
     if (in_array($type, ['x-ui_single', 'alireza_single', 's_ui'], true)) {
+        if ($type === 'x-ui_single' && $xuiToken !== '') {
+            $rt = faoxima_http_get(
+                $url . '/panel/api/inbounds/list',
+                ['Authorization: Bearer ' . $xuiToken, 'Accept: application/json', 'X-Requested-With: XMLHttpRequest']
+            );
+            if (!$rt['ok']) {
+                return ['ok' => false, 'verified' => false, 'message' => 'اتصال ناموفق: ' . $rt['error']];
+            }
+            $jt = json_decode((string)$rt['body'], true);
+            if (is_array($jt) && array_key_exists('success', $jt)) {
+                if (filter_var($jt['success'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === true) {
+                    return ['ok' => true, 'verified' => true, 'message' => 'توکن API معتبر است ✅ (حالت 3x-ui توکنی)'];
+                }
+                return ['ok' => true, 'verified' => false, 'message' => '❌ توکن API نامعتبر است (' . (string)($jt['msg'] ?? 'success=false') . ')'];
+            }
+            if ($rt['code'] === 401 || $rt['code'] === 403) {
+                return ['ok' => true, 'verified' => false, 'message' => '❌ توکن API نادرست (HTTP ' . $rt['code'] . ')'];
+            }
+            return ['ok' => true, 'verified' => false, 'message' => '❌ پاسخ نامعتبر برای توکن API (HTTP ' . $rt['code'] . ')'];
+        }
         if ($username === '' || $password === '') {
             return ['ok' => true, 'verified' => false, 'message' => 'یوزرنیم یا پسورد خالی است'];
         }
@@ -384,6 +404,7 @@ if (isset($_GET['ajax']) && $_GET['ajax'] === 'test_auth') {
     $username = trim((string)($_POST['username'] ?? ''));
     $password =       (string)($_POST['password'] ?? '');
     $apiKey   = trim((string)($_POST['api_key']  ?? ''));
+    $xuiToken = trim((string)($_POST['xui_api_token'] ?? ''));
     $type     = trim((string)($_POST['type']     ?? 'marzban'));
 
     if ($type === 'Manualsale') {
@@ -413,7 +434,19 @@ if (isset($_GET['ajax']) && $_GET['ajax'] === 'test_auth') {
         }
     }
 
-    $result = faoxima_test_panel_auth($url, $username, $password, $apiKey, $type);
+    if ($xuiToken === '' && !empty($_POST['panel_id'])) {
+        $pid = (int)$_POST['panel_id'];
+        if ($pid > 0) {
+            try {
+                $curT = $pdo->prepare("SELECT xui_api_token FROM marzban_panel WHERE id = :id LIMIT 1");
+                $curT->execute([':id' => $pid]);
+                $rowT = $curT->fetch(PDO::FETCH_ASSOC) ?: [];
+                $xuiToken = (string)($rowT['xui_api_token'] ?? '');
+            } catch (\Throwable $e) {}
+        }
+    }
+
+    $result = faoxima_test_panel_auth($url, $username, $password, $apiKey, $type, $xuiToken);
     echo json_encode($result);
     exit;
 }
@@ -721,6 +754,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $userPanel = trim((string)($_POST['username_panel'] ?? ''));
         $passPanel = (string)($_POST['password_panel']      ?? '');
         $apiKey    = trim((string)($_POST['api_key']        ?? ''));
+        $xuiToken  = trim((string)($_POST['xui_api_token']  ?? ''));
         $type      = trim((string)($_POST['type']           ?? 'marzban'));
         $agent     = (string)($_POST['agent']               ?? 'all');
 
@@ -773,9 +807,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
 
 
-            if ($userPanel === '' && $passPanel === '' && $apiKey === '') {
+            if ($userPanel === '' && $passPanel === '' && $apiKey === '' && $xuiToken === '') {
                 $errors[] = 'حداقل باید یوزرنیم و پسورد یا API key وارد شود.';
-            } elseif ($userPanel === '' && $apiKey === '') {
+            } elseif ($userPanel === '' && $apiKey === '' && $xuiToken === '') {
                 $errors[] = 'یوزرنیم خالی است — اگر فقط با API key احراز هویت می‌کنید، آن را وارد کنید.';
             }
         }
@@ -790,7 +824,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $testNote      = '';
 
             if ($type !== 'Manualsale') {
-                $auth = faoxima_test_panel_auth($urlPanel, $userPanel, $passPanel, $apiKey, $type);
+                $auth = faoxima_test_panel_auth($urlPanel, $userPanel, $passPanel, $apiKey, $type, $xuiToken);
 
 
                 error_log(sprintf(
@@ -852,8 +886,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                 $stmt = $pdo->prepare(
                     "INSERT INTO marzban_panel
-                     (code_panel, name_panel, status, url_panel, username_panel, password_panel, api_key, type, agent)
-                     VALUES (:c, :n, :st, :u, :user, :pass, :api, :type, :agent)"
+                     (code_panel, name_panel, status, url_panel, username_panel, password_panel, api_key, xui_api_token, type, agent)
+                     VALUES (:c, :n, :st, :u, :user, :pass, :api, :xt, :type, :agent)"
                 );
                 $stmt->execute([
                     ':c'    => $codePanel,
@@ -863,6 +897,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     ':user' => $userPanel,
                     ':pass' => $passPanel,
                     ':api'  => $apiKey,
+                    ':xt'   => $xuiToken,
                     ':type' => $type,
                     ':agent'=> $agent,
                 ]);
@@ -887,6 +922,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $userPanel = trim((string)($_POST['username_panel'] ?? ''));
         $passPanel = (string)($_POST['password_panel']      ?? '');
         $apiKey    = trim((string)($_POST['api_key']        ?? ''));
+        $xuiToken  = trim((string)($_POST['xui_api_token']  ?? ''));
+        $xuiTokenClear = !empty($_POST['xui_api_token_clear']);
         $type      = trim((string)($_POST['type']           ?? 'marzban'));
         $agent     = (string)($_POST['agent']               ?? 'all');
         $status    = !empty($_POST['status']) ? 'active' : 'inactive';
@@ -970,7 +1007,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                 $skipTest = false;
                 $skipNote = '';
-                if ($passPanel === '' && $apiKey === '') {
+                if ($passPanel === '' && $apiKey === '' && $xuiToken === '' && !$xuiTokenClear) {
                     try {
                         $prevStmt = $pdo->prepare("SELECT status, url_panel, username_panel FROM marzban_panel WHERE id = :id");
                         $prevStmt->execute([':id' => $id]);
@@ -1020,13 +1057,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                 $effectivePass = $passPanel;
                 $effectiveKey  = $apiKey;
-                if ($effectivePass === '' || $effectiveKey === '') {
+                $effectiveToken = $xuiTokenClear ? '' : $xuiToken;
+                if ($effectivePass === '' || $effectiveKey === '' || ($effectiveToken === '' && !$xuiTokenClear)) {
                     try {
-                        $curStmt = $pdo->prepare("SELECT password_panel, api_key FROM marzban_panel WHERE id = :id");
+                        $curStmt = $pdo->prepare("SELECT password_panel, api_key, xui_api_token FROM marzban_panel WHERE id = :id");
                         $curStmt->execute([':id' => $id]);
                         $cur = $curStmt->fetch(PDO::FETCH_ASSOC) ?: [];
                         if ($effectivePass === '') $effectivePass = (string)($cur['password_panel'] ?? '');
                         if ($effectiveKey  === '') $effectiveKey  = (string)($cur['api_key']        ?? '');
+                        if ($effectiveToken === '' && !$xuiTokenClear) $effectiveToken = (string)($cur['xui_api_token'] ?? '');
                     } catch (\Throwable $e) {  }
                 }
 
@@ -1041,7 +1080,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'key_source'       => $apiKey   !== '' ? 'form' : 'db',
                 ]);
 
-                $auth = faoxima_test_panel_auth($urlPanel, $userPanel, $effectivePass, $effectiveKey, $type);
+                $auth = faoxima_test_panel_auth($urlPanel, $userPanel, $effectivePass, $effectiveKey, $type, $effectiveToken);
 
 
                 error_log(sprintf(
@@ -1123,6 +1162,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if (!$authFailed) {
                     if ($passPanel !== '') { $sets[] = "password_panel = :pass"; $params[':pass'] = $passPanel; }
                     if ($apiKey    !== '') { $sets[] = "api_key = :api";          $params[':api']  = $apiKey;    }
+                }
+                if ($xuiTokenClear) {
+                    $sets[] = "xui_api_token = :xt"; $params[':xt'] = '';
+                } elseif ($xuiToken !== '') {
+                    $sets[] = "xui_api_token = :xt"; $params[':xt'] = $xuiToken;
                 }
                 if ($valUsertest    !== null && $valUsertest    !== '') { $sets[] = "val_usertest = :vu";    $params[':vu']  = $valUsertest; }
                 if ($timeUsertest   !== null && $timeUsertest   !== '') { $sets[] = "time_usertest = :tu";   $params[':tu']  = $timeUsertest; }
@@ -1427,6 +1471,12 @@ function faoxima_is_truthy_panel_flag($v, $trueValues) {
                                         <span class="info-line__k">API Key:</span>
                                         <span class="info-line__v"><?php echo faoxima_mask_secret($p['api_key'] ?? ''); ?></span>
                                     </div>
+                                    <?php if ($type === 'x-ui_single' && trim((string)($p['xui_api_token'] ?? '')) !== ''): ?>
+                                    <div class="info-line">
+                                        <span class="info-line__k">توکن 3x-ui:</span>
+                                        <span class="info-line__v"><?php echo faoxima_mask_secret($p['xui_api_token'] ?? ''); ?> <small style="color:var(--success,#16a34a)">(حالت توکنی فعال)</small></span>
+                                    </div>
+                                    <?php endif; ?>
                                 <?php else: ?>
                                     <div class="info-line" style="color:var(--text-muted); font-style:italic;">پنل فروش دستی — بدون اتصال API. کانفیگ‌ها به‌صورت دستی از انبار خارج می‌شوند.</div>
                                 <?php endif; ?>
@@ -1672,6 +1722,11 @@ function faoxima_is_truthy_panel_flag($v, $trueValues) {
                 <label class="form-label">API Key (اختیاری)</label>
                 <input type="text" name="api_key" class="form-control" style="direction:ltr" autocomplete="off">
             </div>
+            <div class="form-group" id="addXuiTokenGroup" style="display:none">
+                <label class="form-label">توکن API پنل 3x-ui (صنایی نسخه جدید)</label>
+                <input type="text" name="xui_api_token" id="xui_api_token" class="form-control" style="direction:ltr" autocomplete="off" placeholder="Settings → Telegram/Subscription → API token">
+                <small style="opacity:.75">برای نسخه‌های جدید 3x-ui که با یوزرنیم/پسورد کار نمی‌کنند، توکن API را اینجا وارد کنید. در این حالت ربات از مسیر <code>/panel/api/clients/*</code> استفاده می‌کند.</small>
+            </div>
             <div class="form-group">
                 <label class="form-label">گروه کاربری</label>
                 <select name="agent" class="form-control">
@@ -1740,6 +1795,14 @@ function faoxima_is_truthy_panel_flag($v, $trueValues) {
             <div class="form-group">
                 <label class="form-label">API Key جدید <small style="color:var(--text-muted)">(خالی = بدون تغییر)</small></label>
                 <input type="text" name="api_key" class="form-control" style="direction:ltr" autocomplete="off" placeholder="برای تغییر API key، اینجا تایپ کنید">
+            </div>
+            <div class="form-group" id="edit_xui_token_group" style="display:none">
+                <label class="form-label">توکن API پنل 3x-ui (صنایی نسخه جدید) <small style="color:var(--text-muted)">(خالی = بدون تغییر)</small></label>
+                <input type="text" name="xui_api_token" id="edit_xui_api_token" class="form-control" style="direction:ltr" autocomplete="off" placeholder="برای تغییر توکن، اینجا تایپ کنید">
+                <label style="display:flex; align-items:center; gap:6px; margin-top:6px; font-size:12px;">
+                    <input type="checkbox" name="xui_api_token_clear" value="1"> حذف توکن و بازگشت به حالت یوزرنیم/پسورد
+                </label>
+                <small style="opacity:.75">با تنظیم توکن، ربات برای این پنل از API توکنی 3x-ui (مسیر <code>/panel/api/clients/*</code>) استفاده می‌کند.</small>
             </div>
             <div class="form-row">
                 <div class="form-group">
@@ -1879,6 +1942,8 @@ function toggleUrlField(type) {
     document.getElementById('addUrlGroup').style.display    = hide ? 'none' : '';
     document.getElementById('addCredsGroup').style.display  = hide ? 'none' : '';
     document.getElementById('addApiGroup').style.display    = hide ? 'none' : '';
+    var xt = document.getElementById('addXuiTokenGroup');
+    if (xt) xt.style.display = (type === 'x-ui_single') ? '' : 'none';
     var u = document.getElementById('addUrlInput');
     if (u) u.required = !hide;
 }
@@ -1897,6 +1962,7 @@ function testPanelAuth(mode) {
     var username = (document.getElementById(prefix + 'username_panel') || {}).value || '';
     var password = (document.getElementById(prefix + 'password_panel') || {}).value || '';
     var apiKey   = (document.getElementById(prefix + 'api_key')        || {}).value || '';
+    var xuiToken = (document.getElementById(prefix + 'xui_api_token')  || {}).value || '';
     var type     = (document.getElementById(prefix + 'type')           || {}).value || 'marzban';
     var panelId  = mode === 'edit' ? ((document.getElementById('edit_id') || {}).value || '') : '';
 
@@ -1924,6 +1990,7 @@ function testPanelAuth(mode) {
     fd.append('username', username);
     fd.append('password', password);
     fd.append('api_key',  apiKey);
+    fd.append('xui_api_token', xuiToken);
     fd.append('type',     type);
     if (panelId) fd.append('panel_id', panelId);
 
@@ -2035,6 +2102,9 @@ function openEdit(d) {
     setIfExists('edit_linksubx',        d.linksubx);
     setIfExists('edit_secret_code',     d.secret_code);
     setIfExists('edit_namecustom',      d.namecustom);
+    setIfExists('edit_xui_api_token',   '');
+    var xtClear = document.querySelector('#edit_xui_token_group input[name="xui_api_token_clear"]');
+    if (xtClear) xtClear.checked = false;
 
     // نمایش/مخفی فیلدهای پیشرفته بر اساس نوع پنل
     applyAdvancedFieldsVisibility(d.type || 'marzban');
@@ -2094,10 +2164,12 @@ function applyAdvancedFieldsVisibility(type) {
     var grpInbound    = document.getElementById('edit_inboundid_group');
     var grpSublink    = document.getElementById('edit_linksubx_group');
     var grpSecretCode = document.getElementById('edit_secret_code_group');
+    var grpXuiToken   = document.getElementById('edit_xui_token_group');
 
     if (grpInbound)    grpInbound.style.display    = needsInbound    ? '' : 'none';
     if (grpSublink)    grpSublink.style.display    = needsSublink    ? '' : 'none';
     if (grpSecretCode) grpSecretCode.style.display = needsSecretCode ? '' : 'none';
+    if (grpXuiToken)   grpXuiToken.style.display   = (type === 'x-ui_single') ? '' : 'none';
 }
 
 // نمایش فیلد "متن پیشوند" وقتی MethodUsername از نوع "متن دلخواه" باشد

--- a/panel/settings.php
+++ b/panel/settings.php
@@ -131,6 +131,19 @@ $SETTING_GROUPS = [
             ['type' => 'toggle', 'col' => 'premium_emoji_status','label' => 'ایموجی پریمیوم تلگرام',        'on' => '1',                   'off' => '0'],
         ],
     ],
+
+    'proxy' => [
+        'title' => 'پراکسی (برای هاست‌های ایران)',
+        'icon'  => 'shield',
+        'fields' => [
+            ['type' => 'toggle', 'col' => 'proxy_telegram_status', 'label' => 'استفاده از پراکسی برای اتصال به تلگرام', 'on' => '1', 'off' => '0'],
+            ['type' => 'text',   'col' => 'proxy_telegram_url',    'label' => 'آدرس پراکسی تلگرام', 'placeholder' => 'socks5h://user:pass@1.2.3.4:1080',
+             'hint'  => 'قالب: scheme://[user:pass@]host:port — پشتیبانی از http، socks4، socks5 و socks5h. اگر scheme ننویسید http در نظر گرفته می‌شود. برای رد کردن DNS از داخل ایران، socks5h توصیه می‌شود.'],
+            ['type' => 'toggle', 'col' => 'proxy_panel_status',    'label' => 'استفاده از پراکسی برای اتصال به پنل‌ها', 'on' => '1', 'off' => '0'],
+            ['type' => 'text',   'col' => 'proxy_panel_url',       'label' => 'آدرس پراکسی پنل‌ها', 'placeholder' => 'socks5h://user:pass@1.2.3.4:1080',
+             'hint'  => 'برای اتصال ربات به پنل‌های خارج از ایران (مرزبان، 3x-ui و …) از این پراکسی استفاده می‌شود. می‌توانید همان پراکسی تلگرام را وارد کنید.'],
+        ],
+    ],
 ];
 
 

--- a/proxy.php
+++ b/proxy.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * Outbound proxy support for Faoxima.
+ *
+ * Some operators run the bot on Iran-based hosts that cannot reach
+ * api.telegram.org or foreign VPN panels directly. They can configure an
+ * HTTP/SOCKS proxy (separately for Telegram and for panel connections) from
+ * the admin settings page; these helpers read that configuration and apply it
+ * to any cURL handle.
+ *
+ * Settings live on the single `setting` row:
+ *   proxy_telegram_status / proxy_telegram_url
+ *   proxy_panel_status    / proxy_panel_url
+ * A URL looks like: socks5h://user:pass@1.2.3.4:1080  (scheme optional, http assumed)
+ */
+
+if (!function_exists('faoxima_proxy_settings')) {
+    function faoxima_proxy_settings($forceReload = false)
+    {
+        static $cache = null;
+        if ($cache !== null && !$forceReload) {
+            return $cache;
+        }
+        $cache = [
+            'telegram_status' => '0',
+            'telegram_url'    => '',
+            'panel_status'    => '0',
+            'panel_url'       => '',
+        ];
+        $pdo = $GLOBALS['pdo'] ?? null;
+        if ($pdo instanceof PDO) {
+            try {
+                $stmt = $pdo->query("SELECT proxy_telegram_status, proxy_telegram_url, proxy_panel_status, proxy_panel_url FROM setting LIMIT 1");
+                $row = $stmt ? $stmt->fetch(PDO::FETCH_ASSOC) : null;
+                if (is_array($row)) {
+                    $cache['telegram_status'] = (string) ($row['proxy_telegram_status'] ?? '0');
+                    $cache['telegram_url']    = trim((string) ($row['proxy_telegram_url'] ?? ''));
+                    $cache['panel_status']    = (string) ($row['proxy_panel_status'] ?? '0');
+                    $cache['panel_url']       = trim((string) ($row['proxy_panel_url'] ?? ''));
+                }
+            } catch (\Throwable $e) {
+                // Columns may not exist yet on an un-migrated DB — fall back to "off".
+            }
+        }
+        return $cache;
+    }
+}
+
+if (!function_exists('faoxima_parse_proxy_url')) {
+    /**
+     * Parse a proxy URL into cURL options. Returns null when the URL is empty
+     * or unusable. Defaults to an HTTP proxy when no scheme is given.
+     */
+    function faoxima_parse_proxy_url($url)
+    {
+        $url = trim((string) $url);
+        if ($url === '') {
+            return null;
+        }
+        if (!preg_match('~^[a-z0-9]+://~i', $url)) {
+            $url = 'http://' . $url;
+        }
+        $p = parse_url($url);
+        if (!is_array($p) || empty($p['host'])) {
+            return null;
+        }
+        $scheme = strtolower($p['scheme'] ?? 'http');
+        $typeMap = [
+            'http'    => CURLPROXY_HTTP,
+            'https'   => CURLPROXY_HTTP,
+            'socks4'  => CURLPROXY_SOCKS4,
+            'socks4a' => CURLPROXY_SOCKS4A,
+            'socks5'  => CURLPROXY_SOCKS5,
+            'socks5h' => CURLPROXY_SOCKS5_HOSTNAME,
+        ];
+        $type = $typeMap[$scheme] ?? CURLPROXY_HTTP;
+        $port = isset($p['port']) ? (int) $p['port'] : (strpos($scheme, 'socks') === 0 ? 1080 : 8080);
+        $userpwd = '';
+        if (isset($p['user'])) {
+            $userpwd = rawurldecode($p['user']) . ':' . rawurldecode($p['pass'] ?? '');
+        }
+        return [
+            'type'    => $type,
+            'host'    => $p['host'],
+            'port'    => $port,
+            'userpwd' => $userpwd,
+            'scheme'  => $scheme,
+        ];
+    }
+}
+
+if (!function_exists('faoxima_proxy_for')) {
+    /**
+     * Resolve the active proxy options for a scope ('telegram' | 'panel').
+     * Returns null when no proxy is enabled/configured for that scope.
+     */
+    function faoxima_proxy_for($scope)
+    {
+        $s = faoxima_proxy_settings();
+        if ($scope === 'telegram') {
+            $status = $s['telegram_status'];
+            $url    = $s['telegram_url'];
+        } else {
+            $status = $s['panel_status'];
+            $url    = $s['panel_url'];
+        }
+        if ((string) $status !== '1' || $url === '') {
+            return null;
+        }
+        return faoxima_parse_proxy_url($url);
+    }
+}
+
+if (!function_exists('faoxima_apply_curl_proxy')) {
+    /**
+     * Apply the configured proxy for $scope to an existing cURL handle.
+     * Returns true when a proxy was applied, false otherwise.
+     */
+    function faoxima_apply_curl_proxy($ch, $scope)
+    {
+        if (!is_resource($ch) && !($ch instanceof \CurlHandle)) {
+            return false;
+        }
+        $proxy = faoxima_proxy_for($scope);
+        if ($proxy === null) {
+            return false;
+        }
+        curl_setopt($ch, CURLOPT_PROXY, $proxy['host']);
+        curl_setopt($ch, CURLOPT_PROXYPORT, $proxy['port']);
+        curl_setopt($ch, CURLOPT_PROXYTYPE, $proxy['type']);
+        curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, true);
+        if ($proxy['userpwd'] !== '') {
+            curl_setopt($ch, CURLOPT_PROXYUSERPWD, $proxy['userpwd']);
+        }
+        return true;
+    }
+}

--- a/request.php
+++ b/request.php
@@ -84,6 +84,10 @@ class CurlRequest {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
         }
 
+        if (function_exists('faoxima_apply_curl_proxy')) {
+            faoxima_apply_curl_proxy($ch, 'panel');
+        }
+
         $finalHeaders = $this->prepareHeaders();
         if (!empty($finalHeaders)) {
             curl_setopt($ch, CURLOPT_HTTPHEADER, $finalHeaders);

--- a/s_ui.php
+++ b/s_ui.php
@@ -6,6 +6,7 @@ ini_set('error_log', 'error_log');
 function get_Clients_ui($username,$namepanel){
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $namepanel,"select");
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     $url = $marzban_list_get['url_panel'].'/apiv2/clients';
 curl_setopt_array($curl, array(
   CURLOPT_URL => $url,
@@ -51,7 +52,9 @@ function GetClientsS_UI($username,$namepanel){
     $userdata = get_Clients_ui($username,$namepanel);
     if(!is_array($userdata) || count($userdata) == 0)return [];
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $namepanel,"select");
-    $curl = curl_init();curl_setopt_array($curl, array(
+    $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
+    curl_setopt_array($curl, array(
   CURLOPT_URL => $marzban_list_get['url_panel'].'/apiv2/clients?id='.$userdata['id'],
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => '',
@@ -154,6 +157,7 @@ function addClientS_ui($namepanel, $usernameac, $Expire,$Total,$inboundid,$note)
             )),
         );
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
         CURLOPT_URL => $marzban_list_get['url_panel'].'/apiv2/save',
         CURLOPT_RETURNTRANSFER => true,
@@ -176,6 +180,7 @@ function addClientS_ui($namepanel, $usernameac, $Expire,$Total,$inboundid,$note)
 function updateClientS_ui($namepanel,array $config){
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $namepanel,"select");
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
         CURLOPT_URL => $marzban_list_get['url_panel'].'/apiv2/save',
         CURLOPT_RETURNTRANSFER => true,
@@ -222,12 +227,14 @@ function removeClientS_ui($location,$username){
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $location,"select");
     $data_user = GetClientsS_UI($username,$location);
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     $configpanel = array(
         "object" => 'clients',
         'action' => "del",
         "data" => $data_user['id'],
         );
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
         CURLOPT_URL => $marzban_list_get['url_panel'].'/apiv2/save',
         CURLOPT_RETURNTRANSFER => true,
@@ -250,6 +257,7 @@ return $response;
 function get_onlineclients_ui($name_panel,$username){
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $name_panel,"select");
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
 curl_setopt_array($curl, array(
   CURLOPT_URL => $marzban_list_get['url_panel'].'/apiv2/onlines',
   CURLOPT_RETURNTRANSFER => true,
@@ -275,6 +283,7 @@ curl_close($curl);
 function get_settig($name_panel){
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $name_panel,"select");
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
         CURLOPT_URL => $marzban_list_get['url_panel'].'/apiv2/settings',
         CURLOPT_RETURNTRANSFER => true,

--- a/table.php
+++ b/table.php
@@ -396,6 +396,11 @@ try {
         addFieldToTable("setting", "antispam_msg_count", "5", "VARCHAR(20)");
         addFieldToTable("setting", "antispam_seconds", "3", "VARCHAR(20)");
         addFieldToTable("setting", "antispam_mute_seconds", "5", "VARCHAR(20)");
+
+        addFieldToTable("setting", "proxy_telegram_status", "0", "VARCHAR(20)");
+        addFieldToTable("setting", "proxy_telegram_url", "", "VARCHAR(500)");
+        addFieldToTable("setting", "proxy_panel_status", "0", "VARCHAR(20)");
+        addFieldToTable("setting", "proxy_panel_url", "", "VARCHAR(500)");
     }
 } catch (Exception $e) {
     error_log('[panels] ' . $e->getMessage());

--- a/table.php
+++ b/table.php
@@ -469,6 +469,7 @@ try {
         username_panel varchar(200) NULL,
         password_panel varchar(200) NULL,
         api_key varchar(500) NULL,
+        xui_api_token varchar(1000) NULL,
         agent varchar(200) NULL,
         sublink varchar(500) NULL,
         config varchar(500) NULL,
@@ -545,6 +546,7 @@ try {
         addFieldToTable("marzban_panel", "proxies", null, "TEXT");
         addFieldToTable("marzban_panel", "inbounds", null, "TEXT");
         addFieldToTable("marzban_panel", "api_key", null, "VARCHAR(500)");
+        addFieldToTable("marzban_panel", "xui_api_token", null, "VARCHAR(1000)");
         addFieldToTable("marzban_panel", "customvolume", $VALUE, "TEXT");
         addFieldToTable("marzban_panel", "subvip", "offsubvip", "VARCHAR(60)");
         addFieldToTable("marzban_panel", "changeloc", "offchangeloc", "VARCHAR(60)");

--- a/x-ui_single.php
+++ b/x-ui_single.php
@@ -140,6 +140,7 @@ function panel_login_cookie($code_panel)
 {
     $panel = select("marzban_panel", "*", "code_panel", $code_panel, "select");
     $curl = curl_init();
+    if (function_exists('faoxima_apply_curl_proxy')) faoxima_apply_curl_proxy($curl, 'panel');
     curl_setopt_array($curl, array(
         CURLOPT_URL => $panel['url_panel'] . '/login',
         CURLOPT_RETURNTRANSFER => true,

--- a/x-ui_single.php
+++ b/x-ui_single.php
@@ -4,6 +4,122 @@ require_once 'request.php';
 ini_set('error_log', 'error_log');
 
 
+/**
+ * 3x-ui (MHSanaei) API-token mode helpers.
+ *
+ * Modern 3x-ui (>= v3.1.0, the "multi inbound clients" rework) moved client
+ * CRUD from /panel/api/inbounds/* to /panel/api/clients/* and enforces a CSRF
+ * token on every cookie-authenticated POST. Cookie login therefore can no
+ * longer create/update/delete clients on those panels. The supported path is
+ * an API token (Settings -> generate token) sent as a Bearer header, which
+ * bypasses CSRF and reaches the new client endpoints.
+ *
+ * When a panel row has a non-empty `xui_api_token`, every x-ui_single call uses
+ * this token mode and the new endpoints. When it is empty the legacy cookie
+ * behaviour is used unchanged, so existing older panels keep working.
+ */
+if (!function_exists('xui_panel_uses_token')) {
+    function xui_panel_uses_token($panel)
+    {
+        return is_array($panel)
+            && isset($panel['xui_api_token'])
+            && trim((string) $panel['xui_api_token']) !== '';
+    }
+}
+
+if (!function_exists('xui_panel_token')) {
+    function xui_panel_token($panel)
+    {
+        return trim((string) ($panel['xui_api_token'] ?? ''));
+    }
+}
+
+if (!function_exists('xui_api_token_request')) {
+    /**
+     * Perform an authenticated request against a modern 3x-ui panel using its
+     * API token. Returns the raw CurlRequest result (status/body/error) and, on
+     * a {"success":false} body, sets ['error'] so callers can treat it like the
+     * legacy error shape.
+     */
+    function xui_api_token_request($panel, $method, $path, $jsonBody = null, $timeout = 8)
+    {
+        $base = rtrim((string) ($panel['url_panel'] ?? ''), '/');
+        $req = new CurlRequest($base . $path);
+        $req->setTimeout($timeout);
+        $req->setBearerToken(xui_panel_token($panel));
+        $headers = array('Accept: application/json', 'X-Requested-With: XMLHttpRequest');
+        if ($jsonBody !== null) {
+            $headers[] = 'Content-Type: application/json';
+        }
+        $req->setHeaders($headers);
+
+        $method = strtoupper($method);
+        if ($method === 'GET') {
+            $resp = $req->get();
+        } else {
+            $payload = $jsonBody === null
+                ? ''
+                : (is_string($jsonBody) ? $jsonBody : json_encode($jsonBody));
+            $resp = $req->post($payload);
+        }
+
+        if (isset($resp['body']) && is_string($resp['body'])) {
+            $decoded = json_decode($resp['body'], true);
+            if (is_array($decoded) && array_key_exists('success', $decoded) && $decoded['success'] === false) {
+                $resp['error'] = $decoded['msg'] ?? 'Unknown panel error';
+            }
+        }
+
+        return $resp;
+    }
+}
+
+if (!function_exists('xui_token_single_link')) {
+    /**
+     * Fetch a client's connection links directly from a modern 3x-ui panel via
+     * the token API (/panel/api/clients/links/{email}). Returns the first
+     * vless/vmess/trojan link or null.
+     */
+    function xui_token_single_link($panel, $email)
+    {
+        if (!xui_panel_uses_token($panel) || $email === null || $email === '') {
+            return null;
+        }
+        $resp = xui_api_token_request($panel, 'GET', '/panel/api/clients/links/' . rawurlencode($email), null, 6);
+        if (empty($resp['body'])) {
+            return null;
+        }
+        $decoded = json_decode($resp['body'], true);
+        if (!is_array($decoded)) {
+            return null;
+        }
+        $obj = $decoded['obj'] ?? $decoded;
+        $candidates = array();
+        if (is_string($obj)) {
+            $candidates = preg_split('/\R/', trim($obj)) ?: array();
+        } elseif (is_array($obj)) {
+            foreach ($obj as $item) {
+                if (is_string($item)) {
+                    $candidates[] = $item;
+                } elseif (is_array($item)) {
+                    foreach (array('uri', 'link', 'url') as $k) {
+                        if (!empty($item[$k]) && is_string($item[$k])) {
+                            $candidates[] = $item[$k];
+                        }
+                    }
+                }
+            }
+        }
+        foreach ($candidates as $candidate) {
+            $candidate = trim((string) $candidate);
+            if ($candidate !== '' && preg_match('/^(vless|vmess|trojan):\/\//i', $candidate)) {
+                return $candidate;
+            }
+        }
+        return null;
+    }
+}
+
 if (!function_exists('xuisingle_cookie_path')) {
     function xuisingle_cookie_path() {
         static $path = null;
@@ -357,6 +473,15 @@ function get_single_link_smart($panelBase, $inboundId, $subscriptionUrl, $userna
     if (!empty($result['links'])) {
         return $result['links'][0];
     }
+    if ($panelName) {
+        $panelRowForToken = select("marzban_panel", "*", "name_panel", $panelName, "select");
+        if (xui_panel_uses_token($panelRowForToken)) {
+            $tokenLink = xui_token_single_link($panelRowForToken, $username);
+            if ($tokenLink) {
+                return $tokenLink;
+            }
+        }
+    }
     $fallback = fallback_single_link_from_clients_api($username, $panelName);
     if ($fallback) {
         return $fallback;
@@ -393,6 +518,13 @@ function get_single_link_after_create($panelBase, $inboundId, $subscriptionUrl, 
 function get_clinets($username, $namepanel)
 {
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $namepanel, "select");
+    if (xui_panel_uses_token($marzban_list_get)) {
+        return xui_api_token_request(
+            $marzban_list_get,
+            'GET',
+            '/panel/api/clients/traffic/' . rawurlencode($username)
+        );
+    }
     login($marzban_list_get['code_panel']);
     $base = rtrim($marzban_list_get['url_panel'], '/');
     $url = $base . "/panel/api/inbounds/getClientTraffics/$username";
@@ -447,7 +579,9 @@ function get_clinets($username, $namepanel)
 function addClient($namepanel, $usernameac, $Expire, $Total, $Uuid, $Flow, $subid, $inboundid, $name_product, $note = "")
 {
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $namepanel, "select");
-    login($marzban_list_get['code_panel']);
+    if (!xui_panel_uses_token($marzban_list_get)) {
+        login($marzban_list_get['code_panel']);
+    }
     if ($name_product == "usertest") {
         if ($marzban_list_get['on_hold_test'] == "1") {
             if ($Expire == 0) {
@@ -470,6 +604,35 @@ function addClient($namepanel, $usernameac, $Expire, $Total, $Uuid, $Flow, $subi
         } else {
             $timeservice = $Expire * 1000;
         }
+    }
+    if (xui_panel_uses_token($marzban_list_get)) {
+        $client = array(
+            "id" => $Uuid,
+            "email" => $usernameac,
+            "totalGB" => $Total,
+            "expiryTime" => $timeservice,
+            "enable" => true,
+            "tgId" => "",
+            "subId" => $subid,
+            "limitIp" => 0,
+            "reset" => 0,
+            "comment" => $note,
+        );
+        if ($Flow !== "" && $Flow !== null) {
+            $client["flow"] = $Flow;
+        }
+        if (!isset($usernameac)) {
+            return array('status' => 500, 'msg' => 'username is null');
+        }
+        return xui_api_token_request(
+            $marzban_list_get,
+            'POST',
+            '/panel/api/clients/add',
+            array(
+                'client' => $client,
+                'inboundIds' => array(intval($inboundid)),
+            )
+        );
     }
     $config = array(
         "id" => intval($inboundid),
@@ -513,6 +676,28 @@ function addClient($namepanel, $usernameac, $Expire, $Total, $Uuid, $Flow, $subi
 function updateClient($namepanel, $uuid, array $config)
 {
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $namepanel, "select");
+    if (xui_panel_uses_token($marzban_list_get)) {
+        $settings = $config['settings'] ?? array();
+        if (is_string($settings)) {
+            $settings = json_decode($settings, true);
+        }
+        $client = is_array($settings) && isset($settings['clients'][0]) ? $settings['clients'][0] : null;
+        if (!is_array($client) || empty($client['email'])) {
+            return array(
+                'status' => 500,
+                'body' => json_encode(array('success' => false, 'msg' => 'client email missing')),
+            );
+        }
+        if (isset($client['flow']) && $client['flow'] === '') {
+            unset($client['flow']);
+        }
+        return xui_api_token_request(
+            $marzban_list_get,
+            'POST',
+            '/panel/api/clients/update/' . rawurlencode($client['email']),
+            $client
+        );
+    }
     login($marzban_list_get['code_panel']);
     $configpanel = json_encode($config, true);
     $url = $marzban_list_get['url_panel'] . '/panel/api/inbounds/updateClient/' . $uuid;
@@ -529,6 +714,14 @@ function updateClient($namepanel, $uuid, array $config)
 }
 function ResetUserDataUsagex_uisin($usernamepanel, $namepanel)
 {
+    $panel_token_row = select("marzban_panel", "*", "name_panel", $namepanel, "select");
+    if (xui_panel_uses_token($panel_token_row)) {
+        return xui_api_token_request(
+            $panel_token_row,
+            'POST',
+            '/panel/api/clients/resetTraffic/' . rawurlencode($usernamepanel)
+        );
+    }
     $data_user = get_clinets($usernamepanel, $namepanel);
     $data_user = json_decode($data_user['body'], true)['obj'];
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $namepanel, "select");
@@ -548,6 +741,13 @@ function ResetUserDataUsagex_uisin($usernamepanel, $namepanel)
 function removeClient($location, $username)
 {
     $marzban_list_get = select("marzban_panel", "*", "name_panel", $location, "select");
+    if (xui_panel_uses_token($marzban_list_get)) {
+        return xui_api_token_request(
+            $marzban_list_get,
+            'POST',
+            '/panel/api/clients/del/' . rawurlencode($username)
+        );
+    }
     login($marzban_list_get['code_panel']);
     $url = $marzban_list_get['url_panel'] . "/panel/api/inbounds/{$marzban_list_get['inboundid']}/delClientByEmail/" . $username;
     $headers = array(


### PR DESCRIPTION
سازگاری کامل با آخرین نسخهٔ پنل صنایی (MHSanaei 3x-ui v3.1.0).

نسخه‌های جدید 3x-ui مدیریت کلاینت‌ها را از /panel/api/inbounds/* به گروه /panel/api/clients/* منتقل کرده و روی هر POST کوکی-محور یک توکن CSRF اجباری گذاشته‌اند. به همین دلیل ادغام قدیمی مبتنی بر لاگین کوکی دیگر نمی‌تواند روی این پنل‌ها کلاینت بسازد/ویرایش/حذف کند. این PR یک حالت توکن API (اختیاری و backward-compatible) اضافه می‌کند:

ستون جدید marzban_panel.xui_api_token (هم در CREATE TABLE و هم به‌صورت مهاجرت idempotent از طریق addFieldToTable).
x-ui_single.php: اگر پنل توکن داشته باشد، توابع get_clinets/addClient/updateClient/removeClient/ResetUserDataUsagex_uisin از طریق اندپوینت‌های مدرن /panel/api/clients/* با هدر Authorization: Bearer کار می‌کنند؛ به‌علاوه fallback گرفتن لینک از /panel/api/clients/links/:email. در صورت خالی‌بودن توکن، دقیقاً همان رفتار کوکی قدیمی حفظ می‌شود (بدون regression روی پنل‌های قدیمی‌تر).
panel/panels.php: فیلد توکن در فرم‌های افزودن/ویرایش (فقط برای نوع x-ui_single)، تست اتصال توکن‌محور (GET /panel/api/inbounds/list با Bearer)، ذخیره در افزودن/ویرایش، گزینهٔ پاک‌کردن توکن برای بازگشت به حالت یوزرنیم/پسورد، و نمایش ماسک‌شده در جزئیات پنل.
شکل پاسخ‌ها ({success, msg, obj}) با حالت قدیمی یکسان نگه داشته شده تا مصرف‌کننده‌های موجود در panels.php بدون تغییر کار کنند.

نحوهٔ استفاده
در پنل وب → پنل‌ها → افزودن/ویرایش پنل از نوع «ثنایی تک پورت (Sanaei single)»، فیلد «توکن API پنل 3x-ui» را با توکنی که از خود پنل 3x-ui (بخش Settings) تولید می‌شود پر کنید. از این پس آن پنل در حالت توکنی کار می‌کند.

اعتبارسنجی انجام‌شده در این session: بررسی سینتکس PHP همهٔ فایل‌های تغییر یافته + تست end-to-end آداپتور توکنی در برابر یک مک‌سرور 3x-ui که method/path/Bearer/JSON-body هر فراخوانی را تأیید کرد