### PR TITLE
Fix wallet balance not deducted on partial card-to-card purchase

### DIFF
--- a/re/rx/function/database_helpers_2.php
+++ b/re/rx/function/database_helpers_2.php
@@ -1095,13 +1095,22 @@ function DirectPayment($order_id, $image = 'images.jpg')
                 update("setting", "numbercount", $value);
             }
         }
+        $__paidShortfall = (float)($Payment_report['price'] ?? 0);
+        if ($__paidShortfall > 0) {
+            if (function_exists('balance_atomic_credit')) {
+                balance_atomic_credit($Balance_id['id'], $__paidShortfall);
+            } else {
+                $__creditBal = (float)($Balance_id['Balance'] ?? 0) + $__paidShortfall;
+                update("user", "Balance", $__creditBal, "id", $Balance_id['id']);
+            }
+        }
         if (function_exists('balance_atomic_charge')) {
             $__allowNegBp2 = (($Balance_id['agent'] ?? '') === 'n2') ? (int)($Balance_id['maxbuyagent'] ?? 0) : 0;
             balance_atomic_charge($Balance_id['id'], (float)$get_invoice['price_product'], $__allowNegBp2);
             $__refreshBp = select("user", "*", "id", $Balance_id['id'], "select");
             $Balance_prims = max(0, (int)($__refreshBp['Balance'] ?? 0));
         } else {
-            $Balance_prims = $Balance_id['Balance'] - $get_invoice['price_product'];
+            $Balance_prims = ((float)$Balance_id['Balance'] + $__paidShortfall) - (float)$get_invoice['price_product'];
             if ($Balance_prims <= 0) $Balance_prims = 0;
             update("user", "Balance", $Balance_prims, "id", $Balance_id['id']);
         }


### PR DESCRIPTION
## خلاصه
این Pull Request یک باگ مالی را برطرف میکند که در آن، وقتی کاربر محصولی را می‌خرد که
موجودی کیف پولش برای آن کافی نیست و مابه‌التفاوت را به‌صورت کارت‌به‌کارت (یا هر درگاه/کریپتو)
پرداخت می‌کند، موجودیِ اولیه‌ی کیف پولش از حساب کسر نمی‌شود.

## شرح باگ
سناریوی نمونه:
- حداقل شارژ ربات: ۱۵٬۰۰۰ تومان
- ارزان‌ترین سرویس: ۳۵٬۰۰۰ تومان
- موجودی کاربر: ۲۰٬۰۰۰ تومان

روند فعلی:
۱. چون موجودی کمتر از قیمت محصول است، یک فاکتورِ «پرداخت‌نشده» با **قیمت کاملِ محصول**
   (۳۵٬۰۰۰) ذخیره می‌شود.
۲. ربات از کاربر می‌خواهد فقط **مابه‌التفاوت** (۱۵٬۰۰۰) را کارت‌به‌کارت پرداخت کند.
۳. این مبلغ ۱۵٬۰۰۰ در `Payment_report['price']` ثبت می‌شود.
۴. بعد از تأیید ادمین، تابع `DirectPayment()` سرویس را تحویل می‌دهد و سپس تلاش می‌کند
   **قیمت کامل** را از کیف پول کسر کند